### PR TITLE
Update for firefox 70 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Go to your Firefox profile folder (Help > Troubleshooting Info > Profile Directo
 For Firefox 70 and higher, please change the value : ```toolkit.legacyUserProfileCustomizations.stylesheets``` to true.
 
 ~~~
-**1.** Load about:config in the Firefox address bar.
-**2.** Confirm that you will be careful.
-**3.** Search for toolkit.legacyUserProfileCustomizations.stylesheets using the search at the top.
-**4.** Toggle the preference. True means Firefox supports the CSS files, False that it ignores them.
+1. Load about:config in the Firefox address bar.
+2. Confirm that you will be careful.
+3. Search for toolkit.legacyUserProfileCustomizations.stylesheets using the search at the top.
+4. Toggle the preference. True means Firefox supports the CSS files, False that it ignores them.
 ~~~

--- a/README.md
+++ b/README.md
@@ -11,3 +11,10 @@ These configuration files will provide the following Chrome-like appearance and 
 # How do I install it?
 
 Go to your Firefox profile folder (Help > Troubleshooting Info > Profile Directory) and place them inside your "chrome" folder (create a folder with that name if it's not already there).
+
+For Firefox 70 and higher, please change the value : ```toolkit.legacyUserProfileCustomizations.stylesheets``` to true.
+
+**1.** Load about:config in the Firefox address bar.
+**2.** Confirm that you will be careful.
+**3.** Search for toolkit.legacyUserProfileCustomizations.stylesheets using the search at the top.
+**4.** Toggle the preference. True means Firefox supports the CSS files, False that it ignores them.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Go to your Firefox profile folder (Help > Troubleshooting Info > Profile Directo
 
 For Firefox 70 and higher, please change the value : ```toolkit.legacyUserProfileCustomizations.stylesheets``` to true.
 
+~~~
 **1.** Load about:config in the Firefox address bar.
 **2.** Confirm that you will be careful.
 **3.** Search for toolkit.legacyUserProfileCustomizations.stylesheets using the search at the top.
 **4.** Toggle the preference. True means Firefox supports the CSS files, False that it ignores them.
+~~~


### PR DESCRIPTION
To use Firefox customizations to emulate Google Chrome's UI in firefox 70, we need to set toolkit.legacyUserProfileCustomizations.stylesheets to true 