### PR TITLE
Fix active tab font color on dark themes

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -5,10 +5,6 @@
     border-radius: 7px 7px 0 0 !important;
 }
 
-.tabbrowser-tab[selected="true"] .tab-text.tab-label {
-    color: black !important;            
-}
-
 .tabbrowser-tab[selected="true"] .tab-background {
     border: 0px solid gray !important;  
     border-bottom: none !important;


### PR DESCRIPTION
This will reset the font color on the active tab title.

On Dark themes the title was pure black. This looks dirty, now the color is from the current selected theme.

|Before|After|
|------|-----|
|![before](https://user-images.githubusercontent.com/58821401/97990170-cd0c9b00-1ddf-11eb-9ca8-5be73f4cbbe0.png)|![after](https://user-images.githubusercontent.com/58821401/97990184-d433a900-1ddf-11eb-84b9-330467872073.png)|